### PR TITLE
Add YREC_INPUT, YREC_START env vars to codespace configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,10 @@
 	},
 
 	"remoteEnv": {
-        "PATH": "${containerEnv:PATH}:/workspaces/yrec/src"
+        "PATH": "${containerEnv:PATH}:/workspaces/yrec/src",
+        "YREC_INPUT": "/workspaces/yrec/input",
+        "YREC_START": "/workspaces/yrec/startmodels"
     },
-	
+
 	"postStartCommand": "cd /workspaces/yrec/src; make -j2"
 }


### PR DESCRIPTION
Use absolute paths for input and start models so working directory does not matter when running YREC.
The output directory remains relative to wherever YREC is invoked. (./output)